### PR TITLE
Fix asset name format and simplify executable permissions

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "iwe"
 name = "IWE"
 description = "Markdown files graph navigation and transformation"
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Dmytro Halichenko <dmytrohalichenko@gmail.com>"]
 repository = "https://github.com/iwe-org/zed-iwe"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl IweExtension {
         let info = Self::platform_info(platform, arch)?;
 
         let asset_name = format!(
-            "iwe-{}-{}.{}",
+            "{}-{}.{}",
             release.version,
             info.target_triple,
             info.archive_ext,
@@ -108,9 +108,7 @@ impl IweExtension {
             zed::download_file(&asset.download_url, &archive_path, info.download_type)
                 .map_err(|e| format!("file download failure: {e}"))?;
 
-            if platform != zed::Os::Windows {
-                zed::make_file_executable(&binary_path)?;
-            }
+            zed::make_file_executable(&binary_path)?;
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("reading directory failure {e}"))?;


### PR DESCRIPTION
## Summary

- Remove duplicate `iwe-` prefix from asset name format since `release.version` already includes it (e.g., `iwe-v0.0.60`)
- Remove unnecessary Windows platform check for `make_file_executable` as Zed handles this internally (no-op on Windows)

## Problem

The extension was failing on Windows with:
```
no asset found matching "iwe-iwe-v0.0.60-x86_64-pc-windows-msvc.zip"
```

The asset name was being constructed as `iwe-{release.version}-{target}.{ext}` but `release.version` already contains the `iwe-` prefix from the GitHub tag name, resulting in a double prefix.

## Changes

**Asset name fix:**
```rust
// Before
format!("iwe-{}-{}.{}", release.version, ...)

// After  
format!("{}-{}.{}", release.version, ...)
```

**Executable permissions simplification:**
```rust
// Before
if platform != zed::Os::Windows {
    zed::make_file_executable(&binary_path)?;
}

// After
zed::make_file_executable(&binary_path)?;
```